### PR TITLE
fixed API error in catch block

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,6 +40,7 @@ p{
     padding: 1rem;
 }
 
+.hidden,
 .hidden > *{
 	display: none;
 }
@@ -104,7 +105,7 @@ li:hover{
     margin: 0;
  }
 
- #choices, #result{
+ #choices, #result, #error{
     width: 25%;
  }
 
@@ -125,7 +126,11 @@ li:hover{
     background-color: #84b6ce;
     font-size: 2rem;
  }
-
+/* 
+ #errorMessage{
+    align-self: center;
+ }
+ */
 
  
 

--- a/index.html
+++ b/index.html
@@ -35,8 +35,9 @@
             <ul id="choices">
             </ul>
             <section id="result">
-                
+            
             </section>
+            <p class="hidden" id="errorMessage">You went too fast! Continue in <span id="timeLeft"></span></p>
         </section>
     </main>
     <script type="text/javascript" src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -51,8 +51,22 @@ class TriviaGame {
                 this.displayQuestion();
                 this.displayChoices();
             })
+
+            //error handling of 429: API too many requests
             .catch(err => {
-                console.log(`error ${err}`)
+                console.log(`error ${err}`);
+                let timeLeft = 3;
+                document.querySelector('#timeLeft').innerHTML = timeLeft;
+                document.querySelector('#errorMessage').classList.toggle('hidden');
+                let intervalId = setInterval(() => {
+                    timeLeft--;
+                    document.querySelector('#timeLeft').innerHTML = timeLeft;
+                    if(timeLeft <= 0) {
+                        document.querySelector('#errorMessage').classList.toggle('hidden');
+                        clearInterval(intervalId);
+                        this.makeAPICall();
+                    }
+                },1000);
             });
     }
 


### PR DESCRIPTION
A more elegant solution to the API too many requests error. 

Previously, the user was shown a box displaying a countdown to when the next question should be asked. If the user prematurely clicked "next question" the game would break. 

Now, if the user prematurely clicks "next question" a waiting message appears and disappears when a new API request is able to be made. This is done by handling the error in the catch block. 